### PR TITLE
Fix night time boundary check

### DIFF
--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -16,9 +16,11 @@ export function isNightTime(time, nightStart = '18:00', nightEnd = '06:00') {
 
   // Handle case where night hours span midnight
   if (startMinutes > endMinutes) {
-    return timeMinutes >= startMinutes || timeMinutes <= endMinutes;
+    // Night period is from start time until midnight and from 00:00 until end time
+    return timeMinutes >= startMinutes || timeMinutes < endMinutes;
   } else {
-    return timeMinutes >= startMinutes && timeMinutes <= endMinutes;
+    // Night period does not span midnight
+    return timeMinutes >= startMinutes && timeMinutes < endMinutes;
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust `isNightTime` to treat end boundary as exclusive

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f59676ac0833082620ddefbc28006